### PR TITLE
merge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 ## [中文翻译版](README_CN.md)
 
+> [!WARNInG]
+> FE `v8.x.x` support is not yet here (automated). You need to follow [parent-repo](https://github.com/msojocs/fiddler-everywhere-enhance)
+
 # Fiddler Everywhere Patch (Automated)
 Guides you to Patch Fiddler Everywhere on Windows Automatically. 
 > Parent Repo: https://github.com/msojocs/fiddler-everywhere-enhance

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 ## [中文翻译版](README_CN.md)
 
 > [!WARNInG]
-> FE `v8.x.x` support is not yet here (automated). You need to follow [parent-repo](https://github.com/msojocs/fiddler-everywhere-enhance)
+> FE `v8.x.x` support is not yet automated here. You need to follow [parent-repo](https://github.com/msojocs/fiddler-everywhere-enhance)
 
 # Fiddler Everywhere Patch (Automated)
 Guides you to Patch Fiddler Everywhere on Windows Automatically. 


### PR DESCRIPTION
## Summary by Sourcery

Documentation:
- Add a prominent warning in the README that FE v8.x.x is not yet supported by the automation and link to the parent repository for manual instructions.